### PR TITLE
Added support for environment variables substitution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ In your configuration file:
 ```yaml
 default:
   server:
+    host: 'localhost'
     port: 3000
   database:
     host: 'localhost'
@@ -37,6 +38,7 @@ test:
     db: 'test_db'
 production:
   server:
+    host: $OPENSHIFT_NODEJS_IP
     port: 8000
   database:
     db: 'prod_db'
@@ -47,6 +49,8 @@ production:
 ```
 
 **node-yaml-config** takes the configuration found in default, then overwrites it with the values found in the environment specific parts. The configuration file is loaded synchronously.
+
+Values prefixed with a dollar sign will be substituted with the corresponding environment variable.
 
 ## API
 

--- a/lib/node-yaml-config.js
+++ b/lib/node-yaml-config.js
@@ -42,12 +42,40 @@ function merge(doc, extension) {
   return doc;
 }
 
+function replaceEnvVariables(data) {
+  switch(typeof(data)) {
+    case 'object':
+      for(var key in data) {
+        if(data.hasOwnProperty(key)) {
+          data[key] = replaceEnvVariables(data[key]);
+        }
+      }
+    break;
+    case 'array':
+      return data.map(function(elem) {
+        return replaceEnvVariables(elem);
+      });
+    break;
+    case 'string':
+      var pattern = /^\$(\w+)$/;
+      if(pattern.test(data)) {
+        console.log(process.env);
+        var variableName = data.match(pattern)[1];
+        return variableName in process.env ? process.env[variableName] : null;
+      }
+    break;
+  }
+
+  return data;
+}
+
 /**
 * Reads a yaml configuration file
 */
 
 function read(filename) {
   var data = yaml.load(fs.readFileSync(filename));
+  data = replaceEnvVariables(data);
 
   loaded_files[filename] = data;
 

--- a/lib/node-yaml-config.js
+++ b/lib/node-yaml-config.js
@@ -59,7 +59,6 @@ function replaceEnvVariables(data) {
     case 'string':
       var pattern = /^\$(\w+)$/;
       if(pattern.test(data)) {
-        console.log(process.env);
         var variableName = data.match(pattern)[1];
         return variableName in process.env ? process.env[variableName] : null;
       }

--- a/lib/node-yaml-config.js
+++ b/lib/node-yaml-config.js
@@ -43,26 +43,22 @@ function merge(doc, extension) {
 }
 
 function replaceEnvVariables(data) {
-  switch(typeof(data)) {
-    case 'object':
-      for(var key in data) {
-        if(data.hasOwnProperty(key)) {
-          data[key] = replaceEnvVariables(data[key]);
-        }
+  if(Array.isArray(data)) {
+    return data.map(function(elem) {
+      return replaceEnvVariables(elem);
+    });
+  } else if(typeof(data) === 'object') {
+    for(var key in data) {
+      if(data.hasOwnProperty(key)) {
+        data[key] = replaceEnvVariables(data[key]);
       }
-    break;
-    case 'array':
-      return data.map(function(elem) {
-        return replaceEnvVariables(elem);
-      });
-    break;
-    case 'string':
-      var pattern = /^\$(\w+)$/;
-      if(pattern.test(data)) {
-        var variableName = data.match(pattern)[1];
-        return variableName in process.env ? process.env[variableName] : null;
-      }
-    break;
+    }
+  } else if(typeof(data) === 'string') {
+    var pattern = /^\$(\w+)$/;
+    if(pattern.test(data)) {
+      var variableName = data.match(pattern)[1];
+      return variableName in process.env ? process.env[variableName] : null;
+    }
   }
 
   return data;

--- a/lib/node-yaml-config.js
+++ b/lib/node-yaml-config.js
@@ -28,7 +28,7 @@ function merge(doc, extension) {
 
   for (prop in extension) {
     if (extension.hasOwnProperty(prop)) {
-      if (extension[prop] instanceof Object) {
+      if (extension[prop] instanceof Object && !(extension[prop] instanceof Array)) {
         if (!doc.hasOwnProperty(prop)) {
           doc[prop] = {};
         }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
     "config"
   ],
   "author": "Johann-Michael Thiebaut <johann.thiebaut@gmail.com>",
+  "contributors": [
+    "Johann-Michael Thiebaut <johann.thiebaut@gmail.com>",
+    "Jeroen Pelgrims <jeroen.pelgrims@gmail.com> (http://jeroenpelgrims.be)"
+  ],
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "prepublish" : "npm prune",
-    "test": "make test"
+    "test": "OPENSHIFT_NODEJS_IP=appname.rhcloud.com make test"
   },
   "repository": {
     "type": "git",

--- a/test/config.yml
+++ b/test/config.yml
@@ -21,3 +21,7 @@ production:
     password: 'pass'
   cache:
     dir: 'static'
+  username_blacklist:
+    - login
+    - admin
+    - register

--- a/test/config.yml
+++ b/test/config.yml
@@ -1,5 +1,6 @@
 default:
   server:
+    host: 'localhost'
     port: 3000
   database:
     host: 'localhost'
@@ -12,6 +13,7 @@ test:
     db: 'test_db'
 production:
   server:
+    host: $OPENSHIFT_NODEJS_IP
     port: 8000
   database:
     db: 'prod_db'

--- a/test/test.js
+++ b/test/test.js
@@ -45,7 +45,12 @@ var example_prod_config = {
   },
   cache: {
     dir: 'static'
-  }
+  },
+  username_blacklist: [
+    'login',
+    'admin',
+    'register'
+  ]
 };
 
 var example_new_dev_config = {
@@ -88,6 +93,7 @@ var example_new_prod_config = {
 
 describe('node-yaml-config', function() {
   describe('#load()', function() {
+
     describe('should corectly load the different configurations', function() {
       it('development', function() {
         should.deepEqual(loader.load(file, 'development'), example_dev_config);
@@ -99,8 +105,8 @@ describe('node-yaml-config', function() {
         should.deepEqual(loader.load(file, 'production'), example_prod_config);
       });
     });
-    describe('should not reread the file', function() {
 
+    describe('should not reread the file', function() {
       before(function() {
         fs.renameSync(file, save_file);
       });
@@ -119,11 +125,23 @@ describe('node-yaml-config', function() {
         should.deepEqual(loader.load(file, 'production'), example_prod_config);
       });
     });
+
     describe('should fill environment variables', function() {
       it('production', function() {
         //Setting process.env variables is useless since the tests are run in a different process aparrently
         //Hence the setting of the environment variable in package.json
         should.deepEqual(loader.load(file, 'production'), example_prod_config);
+      });
+    });
+
+    describe('should deserialise array correcly', function() {
+      it('production', function() {
+        var config = loader.load(file, 'production');
+        
+        config.username_blacklist.should.be.instanceof(Array).and.have.lengthOf(3);
+        config.username_blacklist[0].should.be.equal('login');
+        config.username_blacklist[1].should.be.equal('admin');
+        config.username_blacklist[2].should.be.equal('register');
       });
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,8 @@ var save_file = __dirname + '/config.yml.bak';
 var new_file = __dirname + '/config-reload.yml';
 
 var example_dev_config = {
-  server: { 
+  server: {
+    host: 'localhost',
     port: 3000
   },
   database: {
@@ -19,7 +20,8 @@ var example_dev_config = {
 };
 
 var example_test_config = {
-  server: { 
+  server: {
+    host: 'localhost',
     port: 3000
   },
   database: {
@@ -30,7 +32,8 @@ var example_test_config = {
 };
 
 var example_prod_config = {
-  server: { 
+  server: {
+    host: 'appname.rhcloud.com',
     port: 8000
   },
   database: {
@@ -113,6 +116,13 @@ describe('node-yaml-config', function() {
         should.deepEqual(loader.load(file, 'test'), example_test_config);
       });
       it('production', function() {
+        should.deepEqual(loader.load(file, 'production'), example_prod_config);
+      });
+    });
+    describe('should fill environment variables', function() {
+      it('production', function() {
+        //Setting process.env variables is useless since the tests are run in a different process aparrently
+        //Hence the setting of the environment variable in package.json
         should.deepEqual(loader.load(file, 'production'), example_prod_config);
       });
     });


### PR DESCRIPTION
I had a situation where I had fixed values for the development environment, but was provided other settings through environment variables in the production environment. This is the case in PAAS services like Heroku and OpenShift.
Instead of fiddling in the code writing ifs when to use the config and when the environment variables I thought it would be cleaner to add support for environment variable substitution in the yaml-config.

Although at the same time I can see that this might be a bit out of scope for this project.
