### PR TITLE
js-yaml upgraded to version with known vulnerabilities patched

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.3",
   "main": "./lib/node-yaml-config",
   "dependencies": {
-    "js-yaml": "1.0.2",
+    "js-yaml": "~3.5.2",
     "node.extend": "~1.1.3"
   },
   "directories": {


### PR DESCRIPTION
Current package.json references a version of `js-yaml` that has a known vulnerability. This causes projects using `node-yaml-config` to report vulnerabilities when running scanners such as `nsp check`
https://nodesecurity.io/advisories/JS-YAML_Deserialization_Code_Execution
